### PR TITLE
Return of "defaults read" is not properly tested

### DIFF
--- a/workflows.php
+++ b/workflows.php
@@ -315,7 +315,7 @@ class Workflows {
 
 		exec( 'defaults read "'. $b .'" '.$a, $out );	// Execute system call to read plist value
 
-		if ( $out == "" ):
+		if ( empty( $out ) ):
 			return false;
 		endif;
 


### PR DESCRIPTION
Reading plist file with "defaults read" command returns an empty array if the key is not found. The test on the returned value was wrong.
