### PR TITLE
Alfred v2.3 feedback upgrades

### DIFF
--- a/workflows.php
+++ b/workflows.php
@@ -29,8 +29,6 @@ class Workflows {
 	{
 		$this->path = exec('pwd');
 		$this->home = exec('printf $HOME');
-		var_dump($this);
-		var_dump(file_exists('info.plist'));
 
 		if ( file_exists( 'info.plist' ) ):
 			$this->bundle = $this->get( 'bundleid', 'info.plist' );
@@ -188,7 +186,7 @@ class Workflows {
 				if ( $key == 'uid' ):
 					$c->addAttribute( 'uid', $b[$key] );
 				elseif ( $key == 'arg' ):
-					$c->addAttribute( 'arg', $b[$key] );
+          $c->addChild( 'arg', $b[$key]);
 				elseif ( $key == 'type' ):
 					$c->addAttribute( 'type', $b[$key] );
 				elseif ( $key == 'valid' ):
@@ -210,16 +208,18 @@ class Workflows {
 						$c->$key = $b[$key];
 					endif;
         elseif ( $key == 'subtitle' ):
-          if ( gettype($b[$key]) == 'array' ):
+          if ( gettype($b[$key]) == 'array' ):            
             $subtitle_types = ['shift', 'fn', 'ctrl', 'alt', 'cmd'];
             $subtitles = $b[$key];
             $subtitle_keys = array_keys( $subtitles );
             foreach( $subtitle_keys as $subtitle_key ):
-              $c->$key = $subtitle[$subtitle_key];
-              if ( in_array( $subtitle_key, $subtitle_types ) ):
-                $c->$key->addAttrubite( 'mod', $subtitle_key );
+              $subtitle_element = $c->addChild( 'subtitle', $subtitles[$subtitle_key]);
+              if ( in_array( $subtitle_key, $subtitle_types, true ) ):
+                $subtitle_element->addAttribute( 'mod', $subtitle_key );
               endif;
             endforeach;
+          else:
+            $c->$key = $b[$key];
           endif;
 				else:
 					$c->$key = $b[$key];
@@ -317,7 +317,6 @@ class Workflows {
 		else:
 			return false;
 		endif;
-		var_dump($b);
 
 		$out = `defaults read "$b" $a`;	// Execute system call to read plist value
 
@@ -325,9 +324,7 @@ class Workflows {
 			return false;
 		endif;
 
-		var_dump($out);
 		$out = trim($out);
-		var_dump($out);
 		return $out;											// Return item value
 	}
 
@@ -497,4 +494,3 @@ class Workflows {
 		endif;
 	}
 }
-$w = new Workflows();

--- a/workflows.php
+++ b/workflows.php
@@ -29,6 +29,8 @@ class Workflows {
 	{
 		$this->path = exec('pwd');
 		$this->home = exec('printf $HOME');
+		var_dump($this);
+		var_dump(file_exists('info.plist'));
 
 		if ( file_exists( 'info.plist' ) ):
 			$this->bundle = $this->get( 'bundleid', 'info.plist' );
@@ -179,7 +181,7 @@ class Workflows {
 
 		$items = new SimpleXMLElement("<items></items>"); 	// Create new XML element
 
-		foreach( $a as $b ):								// Lop through each object in the array
+		foreach( $a as $b ):								// Loop through each object in the array
 			$c = $items->addChild( 'item' );				// Add a new 'item' element for each object
 			$c_keys = array_keys( $b );						// Grab all the keys for that item
 			foreach( $c_keys as $key ):						// For each of those keys
@@ -207,6 +209,18 @@ class Workflows {
 					else:
 						$c->$key = $b[$key];
 					endif;
+        elseif ( $key == 'subtitle' ):
+          if ( gettype($b[$key]) == 'array' ):
+            $subtitle_types = ['shift', 'fn', 'ctrl', 'alt', 'cmd'];
+            $subtitles = $b[$key];
+            $subtitle_keys = array_keys( $subtitles );
+            foreach( $subtitle_keys as $subtitle_key ):
+              $c->$key = $subtitle[$subtitle_key];
+              if ( in_array( $subtitle_key, $subtitle_types ) ):
+                $c->$key->addAttrubite( 'mod', $subtitle_key );
+              endif;
+            endforeach;
+          endif;
 				else:
 					$c->$key = $b[$key];
 				endif;
@@ -303,14 +317,17 @@ class Workflows {
 		else:
 			return false;
 		endif;
+		var_dump($b);
 
-		exec( 'defaults read "'. $b .'" '.$a, $out );	// Execute system call to read plist value
+		$out = `defaults read "$b" $a`;	// Execute system call to read plist value
 
 		if ( $out == "" ):
 			return false;
 		endif;
 
-		$out = $out[0];
+		var_dump($out);
+		$out = trim($out);
+		var_dump($out);
 		return $out;											// Return item value
 	}
 
@@ -480,3 +497,4 @@ class Workflows {
 		endif;
 	}
 }
+$w = new Workflows();

--- a/workflows.php
+++ b/workflows.php
@@ -468,5 +468,15 @@ class Workflows {
 
 		return $temp;
 	}
-
+	
+	public function internet()
+	{
+		$internet = @fsockopen("www.google.com",80);
+		if($internet):
+			fclose($internet);
+			return true;
+		else:
+			return false;
+		endif;
+	}
 }

--- a/workflows.php
+++ b/workflows.php
@@ -208,12 +208,13 @@ class Workflows {
 						$c->$key = $b[$key];
 					endif;
         elseif ( $key == 'subtitle' ):
-          if ( gettype($b[$key]) == 'array' ):            
+          if ( gettype( $b[$key] ) == 'array' ):            
             $subtitle_types = ['shift', 'fn', 'ctrl', 'alt', 'cmd'];
             $subtitles = $b[$key];
             $subtitle_keys = array_keys( $subtitles );
+            
             foreach( $subtitle_keys as $subtitle_key ):
-              $subtitle_element = $c->addChild( 'subtitle', $subtitles[$subtitle_key]);
+              $subtitle_element = $c->addChild( 'subtitle', $subtitles[$subtitle_key] );
               if ( in_array( $subtitle_key, $subtitle_types, true ) ):
                 $subtitle_element->addAttribute( 'mod', $subtitle_key );
               endif;
@@ -221,6 +222,16 @@ class Workflows {
           else:
             $c->$key = $b[$key];
           endif;
+        elseif ( $key == 'text' && gettype($b[$key]) == 'array' ):
+          $text_types = ['copy', 'largetype'];
+          $texts = $b[$key];
+          $text_keys = array_keys( $texts );
+          
+          foreach( $text_keys as $text_key ):
+            if ( in_array( $text_key, $text_types ) ):
+              $c->addChild( 'text', $texts[$text_key] )->addAttribute( 'type', $text_key );
+            endif;
+          endforeach;
 				else:
 					$c->$key = $b[$key];
 				endif;
@@ -455,13 +466,14 @@ class Workflows {
 	* @param $uid - the uid of the result, should be unique
 	* @param $arg - the argument that will be passed on
 	* @param $title - The title of the result item
-	* @param $sub - The subtitle text for the result item
+	* @param $sub - The subtitle text for the result item; can be an array of mod values or a string
 	* @param $icon - the icon to use for the result item
 	* @param $valid - sets whether the result item can be actioned
+  * @param $text - array with keys 'copy' and/or 'largetype' and their respective string values
 	* @param $auto - the autocomplete value for the result item
 	* @return array - array item to be passed back to Alfred
 	*/
-	public function result( $uid, $arg, $title, $sub, $icon, $valid='yes', $auto=null, $type=null )
+	public function result( $uid, $arg, $title, $sub, $icon, $valid='yes', $text=null, $auto=null, $type=null )
 	{
 		$temp = array(
 			'uid' => $uid,
@@ -470,10 +482,11 @@ class Workflows {
 			'subtitle' => $sub,
 			'icon' => $icon,
 			'valid' => $valid,
+      'text' => $text,
 			'autocomplete' => $auto,
 			'type' => $type
 		);
-
+    
 		if ( is_null( $type ) ):
 			unset( $temp['type'] );
 		endif;

--- a/workflows.php
+++ b/workflows.php
@@ -249,10 +249,9 @@ class Workflows {
 	{
 		if ( is_array( $a ) ):
 			if ( file_exists( $b ) ):
-				$temp = $this->path.'/'.$b;
-			if ( $b == $temp ):
-				$b = $this->path."/".$b;
-			endif;
+				if ( file_exists( $this->path.'/'.$b ) ):
+					$b = $this->path.'/'.$b;
+				endif;
 			elseif ( file_exists( $this->data."/".$b ) ):
 				$b = $this->data."/".$b;
 			elseif ( file_exists( $this->cache."/".$b ) ):
@@ -262,9 +261,8 @@ class Workflows {
 			endif;
 		else:
 			if ( file_exists( $c ) ):
-				$temp = $this->path.'/'.$c;
-				if ( $c == $temp ):
-					$c = $this->path."/".$c;
+				if ( file_exists( $this->path.'/'.$c ) ):
+					$c = $this->path.'/'.$c;
 				endif;
 			elseif ( file_exists( $this->data."/".$c ) ):
 				$c = $this->data."/".$c;
@@ -295,11 +293,10 @@ class Workflows {
 	public function get( $a, $b ) {
 
 		if ( file_exists( $b ) ):
-			$temp = $this->path.'/'.$b;
-			if ( $b == $temp ):
-				$b = $this->path."/".$b;
+			if ( file_exists( $this->path.'/'.$b ) ):
+				$b = $this->path.'/'.$b;
 			endif;
-		elseif ( file_exists( $this->data."/".$b ) ):
+ 		elseif ( file_exists( $this->data."/".$b ) ):
 			$b = $this->data."/".$b;
 		elseif ( file_exists( $this->cache."/".$b ) ):
 			$b = $this->cache."/".$b;
@@ -383,9 +380,8 @@ class Workflows {
 	public function write( $a, $b )
 	{
 		if ( file_exists( $b ) ):
-			$temp = $this->path.'/'.$b;
-			if ( $b == $temp ):
-				$b = $this->path."/".$b;
+			if ( file_exists( $this->path.'/'.$b ) ):
+				$b = $this->path.'/'.$b;
 			endif;
 		elseif ( file_exists( $this->data."/".$b ) ):
 			$b = $this->data."/".$b;
@@ -418,9 +414,8 @@ class Workflows {
 	public function read( $a )
 	{
 		if ( file_exists( $a ) ):
-			$temp = $path.'/'.$a;
-			if ( $a === $temp ):
-				$a = $this->path."/".$a;
+			if ( file_exists( $this->path.'/'.$a ) ):
+				$a = $this->path.'/'.$a;
 			endif;
 		elseif ( file_exists( $this->data."/".$a ) ):
 			$a = $this->data."/".$a;


### PR DESCRIPTION
# Alfred 2.3 support
## Notable changes:

`$sub` argument of `result()` now accepts an associative array of mod values. For example:

``` php
array(
  'Default Subtitle',
  'alt' => 'Alternate subtitle',
  'cmd' => 'Command subtitle',
  'shift' => 'Shift subtitle',
  'fn' => 'Function subtitle',
  'ctrl' => 'Control subtitle'
)
```

If a string is provided rather than an array, it is used in the unmodified `<subtitle>` element (same as previous behavior).

`$text` argument of `result()` is a **breaking change**. It accepts an associative array of values to be used for the `<text>` element. For example:

``` php
array(
  'copy' => 'Copy value',
  'largetype' => 'Largetype value'
)
```
## Minor changes:

Adjustments to `get()` function; not yet tested.

Addition of `internet()` function to check for internet connection (cruft from #1).
