### PR TITLE
Specifying UTF-8 encoding

### DIFF
--- a/workflows.php
+++ b/workflows.php
@@ -4,8 +4,8 @@
 * Description: 	This PHP class object provides several useful functions for retrieving, parsing,
 * 				and formatting data to be used with Alfred 2 Workflows.
 * Author: 		David Ferguson (@jdfwarrior)
-* Revised: 		6/6/2013
-* Version:		0.3.3
+* Revised: 		6/19/2014
+* Version:		0.3.4
 */
 class Workflows {
 
@@ -177,7 +177,7 @@ class Workflows {
 			return false;
 		endif;
 
-		$items = new SimpleXMLElement("<items></items>"); 	// Create new XML element
+		$items = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><items></items>'); // Create new XML element
 
 		foreach( $a as $b ):								// Lop through each object in the array
 			$c = $items->addChild( 'item' );				// Add a new 'item' element for each object


### PR DESCRIPTION
Hello. I added `encoding="UTF-8` to the xml tag. Alfred's output is UTF-8, so I think it makes sense to feed it UTF-8 xml.

The practical effect is that unicode characters now display properly in the Alfred debug console, instead of their html entity escape sequences. The output you see in the prompt and everywhere else is identical to how it was previously.
