### PR TITLE
Find bundle id automatically only if not provided

### DIFF
--- a/workflows.php
+++ b/workflows.php
@@ -30,14 +30,14 @@ class Workflows {
 		$this->path = exec('pwd');
 		$this->home = exec('printf "$HOME"');
 
-		if ( file_exists( 'info.plist' ) ):
-			$this->bundle = $this->get( 'bundleid', 'info.plist' );
-		endif;
-
 		if ( !is_null( $bundleid ) ):
 			$this->bundle = $bundleid;
+		else:
+			if ( file_exists( 'info.plist' ) ):
+				$this->bundle = $this->get( 'bundleid', 'info.plist' );
+			endif;		
 		endif;
-
+		
 		$this->cache = $this->home. "/Library/Caches/com.runningwithcrayons.Alfred-2/Workflow Data/".$this->bundle;
 		$this->data  = $this->home. "/Library/Application Support/Alfred 2/Workflow Data/".$this->bundle;
 


### PR DESCRIPTION
Hi David,

I've found that getting bundled from plist is quite impacting for performance (around 100ms on a macbook pro if I remember) so I decided to provide bundle id when creating workflow, but even with that it tries to get it automatically. This pull request shall fix that.
