### PR TITLE
Performance improvement when providing bundle id

### DIFF
--- a/workflows.php
+++ b/workflows.php
@@ -30,14 +30,14 @@ class Workflows {
 		$this->path = exec('pwd');
 		$this->home = exec('printf "$HOME"');
 
-		if ( file_exists( 'info.plist' ) ):
-			$this->bundle = $this->get( 'bundleid', 'info.plist' );
-		endif;
-
 		if ( !is_null( $bundleid ) ):
 			$this->bundle = $bundleid;
+		else:
+			if ( file_exists( 'info.plist' ) ):
+				$this->bundle = $this->get( 'bundleid', 'info.plist' );
+			endif;		
 		endif;
-
+		
 		$this->cache = $this->home. "/Library/Caches/com.runningwithcrayons.Alfred-2/Workflow Data/".$this->bundle;
 		$this->data  = $this->home. "/Library/Application Support/Alfred 2/Workflow Data/".$this->bundle;
 

--- a/workflows.php
+++ b/workflows.php
@@ -5,7 +5,7 @@
 * 				and formatting data to be used with Alfred 2 Workflows.
 * Author: 		David Ferguson (@jdfwarrior)
 * Revised: 		6/6/2013
-* Version:		0.3.3
+* Version:		0.3.4
 */
 class Workflows {
 
@@ -27,15 +27,15 @@ class Workflows {
 	*/
 	function __construct( $bundleid=null )
 	{
-		$this->path = exec('pwd');
-		$this->home = exec('printf "$HOME"');
+		$this->home = getenv("HOME");
 
 		if ( !is_null( $bundleid ) ):
 			$this->bundle = $bundleid;
 		else:
 			if ( file_exists( 'info.plist' ) ):
+				$this->path();
 				$this->bundle = $this->get( 'bundleid', 'info.plist' );
-			endif;		
+			endif;
 		endif;
 		
 		$this->cache = $this->home. "/Library/Caches/com.runningwithcrayons.Alfred-2/Workflow Data/".$this->bundle;
@@ -122,10 +122,10 @@ class Workflows {
 	public function path()
 	{
 		if ( is_null( $this->path ) ):
-			return false;
-		else:
-			return $this->path;
+			$this->path = exec('pwd');
 		endif;
+		
+		return $this->path;
 	}
 
 	/**

--- a/workflows.php
+++ b/workflows.php
@@ -122,7 +122,7 @@ class Workflows {
 	public function path()
 	{
 		if ( is_null( $this->path ) ):
-			$this->path = exec('pwd');
+			$this->path = getenv("PWD");
 		endif;
 		
 		return $this->path;


### PR DESCRIPTION
This pull request is done to avoid as much as possible the use of exec() in Workflows constructor. When providing bundled when creating Workflows, I get good improvements.

I've created a workflow to show the improvements, get it here https://cloudup.com/cBiUwDy104X

See:

![capture decran 2014-07-12 a 00 35 32](https://cloud.githubusercontent.com/assets/4061923/3559537/b4b831e0-094b-11e4-8cfe-6da5e5cd3370.png)
