### PR TITLE
fix  parameter being ignored when set to true

### DIFF
--- a/workflows.php
+++ b/workflows.php
@@ -437,7 +437,7 @@ class Workflows {
 		$out = file_get_contents( $a );
 		if ( !is_null( json_decode( $out ) ) && !$array ):
 			$out = json_decode( $out );
-		elseif ( !is_null( json_decode( $out ) ) && !$array ):
+		elseif ( !is_null( json_decode( $out ) ) && $array ):
 			$out = json_decode( $out, true );
 		endif;
 


### PR DESCRIPTION
$array = true argument doesn't work as expected
